### PR TITLE
Fixed problem with module importation.

### DIFF
--- a/install.php
+++ b/install.php
@@ -10,7 +10,7 @@
  *
  */
 $sql = "CREATE TABLE IF NOT EXISTS HelloWorld_settings (
-`key` varchar(255) NOT NULL default '',
+`key` varchar(191) NOT NULL default '',
 `value` varchar(255) NOT NULL default '',
 PRIMARY KEY (`key`)
 );";


### PR DESCRIPTION
When we import this module in freePBX returns a error. The problem was in SQL (Error Code: 1071. Specified key was too long; max key length is 767 bytes). Because that, I changed the script (param key size) and the module was imported with successful.